### PR TITLE
Allow users to have any username and multiple roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,40 +77,41 @@ modules:
         PhpBrowser:
             url: 'http://localhost/myapp/'
         DrupalUserRegistry:
-            roles: ['administrator', 'editor', 'sub editor', 'lowly-user', 'authenticated']  # A list of user roles.
-            emails:
-                administrator: 'admin@example.com'
-                editor: 'editor@example.com'
-            password: 'test123!'         # The password to use for all test users.
+            defaultPass: "foobar"
+            users:
+                administrator:
+                    name: administrator
+                    email: admin@example.com
+                    pass: "foo%^&&"
+                    roles: [ administrator, editor ]
+                    root: true
+                editor:
+                    name: editor
+                    email: editor@example.com
+                    roles: [ editor, sub-editor ]
+                "sub editor":
+                    name: "sub editor"
+                    email: "sub.editor@example.com"
+                    roles: [ sub-editor ]
+                authenticated:
+                    name: authenticated
+                    email: authenticated@example.com
+                    roles: [ "authenticated user" ]
             create: true                 # Whether to create all defined test users at the start of the suite.
             delete: true                 # Whether to delete all defined test users at the end of the suite.
             drush-alias: '@mysite.local' # The Drush alias to use when managing users via DrushTestUserManager.
-            root:
-                username: root           # Username for user with uid 1.
-                password: root           # Password for user with uid 1.
             username-prefix: robot       # Use this string instead of the default 'test' for prefixing test usernames.
 ```
 
 ### Required and optional configuration
 
-Configured values for `roles` and `password` are required. `drush-alias` is only currently required as [DrushTestUserManager](https://github.com/pfaocle/codeception-module-drupal-user-registry/blob/master/src/Drupal/UserRegistry/DrushTestUserManager.php) is the only class available for managing (creating/deleting) users.
+Configured values for `users` are required. `drush-alias` is only currently required as [DrushTestUserManager](https://github.com/pfaocle/codeception-module-drupal-user-registry/blob/master/src/Drupal/UserRegistry/DrushTestUserManager.php) is the only class available for managing (creating/deleting) users.
 
 Other optional configuration includes:
 
 * `create` and `delete` are assumed to be `false` if not set.
-* `emails` can optionally be set for any created test users, for use in tests.
-* The `root` key and its `username` and `password` are only required if `$I->getRootUser()` is used.
-* `username-prefix` can be used to set the prefix used for test users' usernames, instead of the default 'test'.
-
-### Derivate usernames
-
-Note that only a list of user roles is defined - no specific usernames. This is because we only need a single representative user account for a given role performing an acceptance test. Each role defined in configuration maps directly to a single user with username derived from the role name. For example, the configuration above would result in the following usernames: _test.administrator_, _test.editor_, _test.sub.editor_, _test.lowly.user_, _test.authenticated_.
-
-Derivative usernames are (by default) prefixed with _test._ and have any character in the role name matching the regex `/(\s|-)/` (i.e. whitespace and hyphens) replaced with a full-stop character (`.`). The test username prefix can be configured to something other than this default using the `username-prefix` key: see _Example suite configuration_, above.
-
-
-**Caution:** no test user is created when the "root" user is configured. If the `getRootUser()` method is to be used the username and password will need to be set to working credentials, **stored in plain text**.
-
+* `defaultPass` can be used to set a default test user password in case you don't want to add a password for each user. It can still be overridden on a per-user basis.
+* The `root` key can be added for any user (preferably just one) to indicate it is the root user (uid 1).
 
 ## Troubleshooting
 

--- a/src/Drupal/UserRegistry/DrupalTestUser.php
+++ b/src/Drupal/UserRegistry/DrupalTestUser.php
@@ -35,6 +35,13 @@ class DrupalTestUser
     public $roles = array();
 
     /**
+     * Whether this user is the root user (user 1).
+     *
+     * @var bool
+     */
+    public $isRoot = false;
+
+    /**
      * Constructor.
      *
      * @param string $name

--- a/src/Drupal/UserRegistry/Storage/ModuleConfigStorage.php
+++ b/src/Drupal/UserRegistry/Storage/ModuleConfigStorage.php
@@ -80,6 +80,12 @@ class ModuleConfigStorage implements StorageInterface
                 $item['email']
             );
 
+            // If user is marked as root user, save this to the user object.
+            if (isset($this->yaml['root']) && $this->yaml['root'] == 'true') {
+                $user->isRoot = true;
+            }
+
+            // Save the user to the collection.
             $this->users[$item['name']] = $user;
         }
 

--- a/src/DrupalUserRegistry.php
+++ b/src/DrupalUserRegistry.php
@@ -123,12 +123,7 @@ class DrupalUserRegistry extends Module
      */
     public function getUser($name)
     {
-        foreach ($this->drupalTestUsers as $drupalTestUser) {
-            if ($drupalTestUser->name == $name) {
-                return $drupalTestUser;
-            }
-        }
-        return false;
+        return isset($this->drupalTestUsers[$name]) ? $this->drupalTestUsers['name'] : false;
     }
 
     /**
@@ -160,30 +155,35 @@ class DrupalUserRegistry extends Module
      */
     public function getRoles()
     {
-        $roles = $this->drupalTestUsers;
-        if (array_key_exists(self::DRUPAL_ROOT_USER_USERNAME, $roles)) {
-            unset($roles[self::DRUPAL_ROOT_USER_USERNAME]);
+        $roles = array();
+
+        // Go through all of the users and collect up the roles.
+        foreach ($this->drupalTestUsers as $user) {
+            if (isset($user->roles)) {
+                foreach ($user->roles as $role) {
+                    $roles[$role] = true;
+                }
+            }
         }
+
         return array_keys($roles);
     }
 
     /**
      * Get the "root" user with  uid 1, if configured.
      *
-     * @return DrupalTestUser
-     *   The configured "root" user.
-     *
-     * @throws ModuleException
+     * @return DrupalTestUser|bool
+     *   The configured "root" user. False if there isn't one.
      */
     public function getRootUser()
     {
-        if (!isset($this->config['root']['username']) || !isset($this->config['root']['password'])) {
-            throw new ModuleException(
-                __CLASS__,
-                "Credentials for the root user (username, password) are not configured."
-            );
+        foreach ($this->drupalTestUsers as $user) {
+            if ($user->isRoot) {
+                return $user;
+            }
         }
-        return new DrupalTestUser($this->config['root']['username'], $this->config['root']['password']);
+
+        return false;
     }
 
     /**

--- a/src/DrupalUserRegistry.php
+++ b/src/DrupalUserRegistry.php
@@ -132,16 +132,24 @@ class DrupalUserRegistry extends Module
     }
 
     /**
-     * Returns a user account object for $role
+     * Returns a user account object for $role.
      *
      * @param string $role
      *   The returned user will be in this role.
      *
-     * @return DrupalTestUser
+     * @return DrupalTestUser|bool
+     *   The first DrupalTestUser to have the requested role, or false if no
+     *   user has that role.
      */
     public function getUserByRole($role)
     {
-        return $this->drupalTestUsers[$role];
+        foreach ($this->drupalTestUsers as $user) {
+            if (isset($user->roles) && in_array($role, $user->roles)) {
+                return $user;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
This should cover all the bases! Users are now their own array in the Yaml and the loader has been altered to accommodate this. Users can have any username and can have multiple roles.

Note that this has side effects. As two users could have the same role, the getUserByRole() method just returns the first user it finds with that role.

Once Yaml in your suite file is changed, everything else should continue to work as normal.